### PR TITLE
Enforce consistent compile flags and add sanitizer preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
+option(ENABLE_SANITIZERS "Enable ASan/UBSan in Debug on non-MSVC builds" ON)
+
 if(MSVC)
   add_compile_options(/W4 /permissive- /utf-8)
 else()
@@ -54,6 +56,24 @@ target_link_libraries(app PRIVATE core
 target_compile_options(app PRIVATE ${GTK_CFLAGS_OTHER} ${GLIB_CFLAGS_OTHER} ${GST_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER})
 target_include_directories(app PRIVATE ${GTK_INCLUDE_DIRS} ${GLIB_INCLUDE_DIRS} ${GST_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS})
 target_link_directories(app PRIVATE ${GTK_LIBRARY_DIRS} ${GLIB_LIBRARY_DIRS} ${GST_LIBRARY_DIRS} ${CURL_LIBRARY_DIRS})
+
+# --- Project-wide compile warnings (already set globally, but ensure targets inherit) ---
+if(MSVC)
+  target_compile_options(core PRIVATE /W4 /permissive- /utf-8)
+  target_compile_options(app  PRIVATE /W4 /permissive- /utf-8)
+else()
+  target_compile_options(core PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_options(app  PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+# --- Sanitizers: only in Debug, only on non-MSVC ---
+if(ENABLE_SANITIZERS AND CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT MSVC)
+  target_compile_options(core PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+  target_link_options(  core PRIVATE -fsanitize=address,undefined)
+
+  target_compile_options(app  PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+  target_link_options(  app  PRIVATE -fsanitize=address,undefined)
+endif()
 
 # ---------- TRAY (Ayatana/AppIndicator) ----------
 if(WITH_TRAY)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,8 @@
   "cmakeMinimumRequired": { "major": 3, "minor": 28 },
   "configurePresets": [
     { "name": "dev", "generator": "Ninja", "binaryDir": "build/dev", "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" } },
+    { "name": "asan", "inherits": "dev", "binaryDir": "build/asan",
+      "cacheVariables": { "ENABLE_SANITIZERS": true, "CMAKE_BUILD_TYPE": "Debug" } },
     { "name": "rel", "generator": "Ninja", "binaryDir": "build/rel", "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" } },
     { "name": "msvc-vcpkg", "generator": "Ninja", "binaryDir": "build/msvc", "cacheVariables": {
       "CMAKE_C_COMPILER": "cl",
@@ -12,11 +14,13 @@
   ],
   "buildPresets": [
     { "name": "dev", "configurePreset": "dev" },
+    { "name": "asan", "configurePreset": "asan" },
     { "name": "rel", "configurePreset": "rel" },
     { "name": "msvc-vcpkg", "configurePreset": "msvc-vcpkg" }
   ],
   "testPresets": [
     { "name": "dev", "configurePreset": "dev" },
+    { "name": "asan", "configurePreset": "asan" },
     { "name": "rel", "configurePreset": "rel" }
   ]
 }

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,0 +1,15 @@
+# Build Presets
+
+Use CMake presets to configure common build types:
+
+- `cmake --preset dev` for a standard Debug build.
+- `cmake --preset asan` for a Debug build with AddressSanitizer/UndefinedBehaviorSanitizer enabled (Unix-like platforms).
+- `cmake --preset rel` for a RelWithDebInfo build.
+
+When debugging sanitizer builds you can enable stricter behavior with:
+
+```sh
+export ASAN_OPTIONS=halt_on_error=1
+```
+
+Set the variable before running the instrumented binary to stop immediately on the first sanitizer report.


### PR DESCRIPTION
## Summary
- add a configurable ENABLE_SANITIZERS option and ensure core/app inherit strict warnings and sanitizer flags
- provide a reusable Address/Undefined sanitizer CMake preset alongside existing dev/rel settings
- document the common presets and sanitizer usage for developers

## Testing
- cmake --preset dev *(fails: missing gtk+-3.0 development package in container)*
- cmake --preset asan *(fails: missing gtk+-3.0 development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5284530b48320b6582b05a20d7c3b