### PR TITLE
Add vcpkg configuration and Windows build documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 .vscode/
 .idea/
 *.user
+*.sln
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,6 +8,7 @@
     { "name": "rel", "generator": "Ninja", "binaryDir": "build/rel", "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" } },
     { "name": "msvc-vcpkg", "generator": "Ninja", "binaryDir": "build/msvc", "cacheVariables": {
       "CMAKE_C_COMPILER": "cl",
+      "CMAKE_BUILD_TYPE": "Debug",
       "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
       "VCPKG_TARGET_TRIPLET": "x64-windows"
     } }
@@ -21,6 +22,7 @@
   "testPresets": [
     { "name": "dev", "configurePreset": "dev" },
     { "name": "asan", "configurePreset": "asan" },
-    { "name": "rel", "configurePreset": "rel" }
+    { "name": "rel", "configurePreset": "rel" },
+    { "name": "msvc-vcpkg", "configurePreset": "msvc-vcpkg" }
   ]
 }

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -1,0 +1,24 @@
+# Building on Windows (MSVC + vcpkg, x64)
+
+## Prereqs
+- Visual Studio 2022 (Desktop development with C++)
+- vcpkg (https://github.com/microsoft/vcpkg) and set `VCPKG_ROOT`
+
+## One-time setup
+```powershell
+# In an x64 Native Tools for VS 2022 shell:
+git clone https://github.com/microsoft/vcpkg %USERPROFILE%\vcpkg
+setx VCPKG_ROOT %USERPROFILE%\vcpkg
+```
+
+## Configure, build, test
+```powershell
+cmake --preset msvc-vcpkg
+cmake --build build\msvc --config Debug
+ctest --test-dir build\msvc -C Debug --output-on-failure
+```
+
+## Notes
+- Dependencies come from vcpkg.json (gtk3, glib, gstreamer, curl, openssl).
+- Tray support (Ayatana/AppIndicator) may be unavailable on Windows: the build will continue without it.
+- Use RelWithDebInfo for release-like builds: `cmake -S . -B build\msvc -DCMAKE_BUILD_TYPE=RelWithDebInfo --preset msvc-vcpkg`

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "modernizedapp",
+  "version-string": "2.3.0",
+  "dependencies": [
+    "gtk",
+    "glib",
+    "gstreamer",
+    "gstreamer-plugins-base",
+    "curl",
+    "openssl"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a vcpkg manifest that captures the Windows dependencies
- document the MSVC + vcpkg workflow and adjust presets for the new toolchain
- ignore legacy Visual Studio project files that remain in the tree

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5470123b88320a1178f62bf3ccc0e